### PR TITLE
Fix threading warnings and issues

### DIFF
--- a/LayerPlayer/Views/TilingView.swift
+++ b/LayerPlayer/Views/TilingView.swift
@@ -33,9 +33,11 @@ import UIKit
 class TilingView: UIView {
   
   let sideLength = CGFloat(100.0)
-    var offset: CGFloat = 0
-    var x: CGFloat = 0
-    var y: CGFloat = 0
+    
+  // Helper variables to prevent `draw(rect:)` from accessing `bounds` on a global queue
+  var offset: CGFloat = 0
+  var x: CGFloat = 0
+  var y: CGFloat = 0
   
   override class var layerClass : AnyClass {
     return TiledLayer.self

--- a/LayerPlayer/Views/TilingView.swift
+++ b/LayerPlayer/Views/TilingView.swift
@@ -33,6 +33,9 @@ import UIKit
 class TilingView: UIView {
   
   let sideLength = CGFloat(100.0)
+    var offset: CGFloat = 0
+    var x: CGFloat = 0
+    var y: CGFloat = 0
   
   override class var layerClass : AnyClass {
     return TiledLayer.self
@@ -45,20 +48,26 @@ class TilingView: UIView {
     layer.contentsScale = UIScreen.main.scale
     layer.tileSize = CGSize(width: sideLength, height: sideLength)
   }
+    
+  override func layoutSubviews() {
+        super.layoutSubviews()
+    
+        let scale = UIScreen.main.scale
+        x = bounds.origin.x
+        y = bounds.origin.y
+        offset = bounds.width / sideLength * (scale == 3 ? 2 : scale)
+    }
   
   override func draw(_ rect: CGRect) {
     let context = UIGraphicsGetCurrentContext()
     let scale = UIScreen.main.scale
     
     var red = CGFloat(drand48())
-    var green = CGFloat(drand48())
+    var green = CGFloat(drand48())  
     var blue = CGFloat(drand48())
     context?.setFillColor(red: red, green: green, blue: blue, alpha: 1.0)
     context?.fill(rect)
     
-    let x = bounds.origin.x
-    let y = bounds.origin.y
-    let offset = bounds.width / sideLength * (scale == 3 ? 2 : scale)
     context?.move(to: CGPoint(x: x + 9.0 * offset, y: y + 43.0 * offset))
     context?.addLine(to: CGPoint(x: x + 18.06 * offset, y: y + 22.6 * offset))
     context?.addLine(to: CGPoint(x: x + 25.0 * offset, y: y + 7.5 * offset))

--- a/LayerPlayer/Views/TilingViewForImage.swift
+++ b/LayerPlayer/Views/TilingViewForImage.swift
@@ -36,6 +36,7 @@ let fileName = "windingRoad"
 class TilingViewForImage: UIView {
   
   let cachesPath = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)[0] as String
+  var currentBounds = CGRect.zero
   
   override class var layerClass : AnyClass {
     return TiledLayer.self
@@ -47,6 +48,12 @@ class TilingViewForImage: UIView {
     layer.contentsScale = UIScreen.main.scale
     layer.tileSize = CGSize(width: sideLength, height: sideLength)
   }
+    
+   override func layoutSubviews() {
+      super.layoutSubviews()
+    
+      currentBounds = self.bounds
+   }
   
   override func draw(_ rect: CGRect) {
     let firstColumn = Int(rect.minX / sideLength)
@@ -62,7 +69,7 @@ class TilingViewForImage: UIView {
           let point = CGPoint(x: x, y: y)
           let size = CGSize(width: sideLength, height: sideLength)
           var tileRect = CGRect(origin: point, size: size)
-          tileRect = bounds.intersection(tileRect)
+          tileRect = currentBounds.intersection(tileRect)
           tile.draw(in: tileRect)
         }
       }

--- a/LayerPlayer/Views/TilingViewForImage.swift
+++ b/LayerPlayer/Views/TilingViewForImage.swift
@@ -36,6 +36,8 @@ let fileName = "windingRoad"
 class TilingViewForImage: UIView {
   
   let cachesPath = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)[0] as String
+
+  // Helper variable to prevent `draw(rect:)` from accessing `bounds` on a global queue
   var currentBounds = CGRect.zero
   
   override class var layerClass : AnyClass {


### PR DESCRIPTION
Users commented that they're having warnings and possible crashes connected to `draw(rect:)` method being called in a global queue and `bounds` property being accessed from not-a-main dispatch.

What I did to solve that was create new variables and use them instead.